### PR TITLE
debug_keyboard_pressed function in ai_update.gml

### DIFF
--- a/scripts/ai_update.gml
+++ b/scripts/ai_update.gml
@@ -1,4 +1,4 @@
-load_some_attack_data()
+if(load_some_attack_data()) exit;
 
 xdisp = ai_target.x - x
 ydisp = ai_target.y - y
@@ -41,9 +41,9 @@ if contains([AT_FAIR, AT_NAIR, AT_BAIR, AT_UAIR, AT_DAIR], attack){
 		repeat(1) learn();
 		
 		// if(learning_frame > 15) currently_learning = false;
-		learning_frame++; exit;
+		learning_frame++; return(true);
 	} else {
-		currently_learning = false
+		currently_learning = false; return(false);
 	}
 	/*else {
 		if(learning_frame != 69) {

--- a/scripts/ai_update.gml
+++ b/scripts/ai_update.gml
@@ -1,4 +1,4 @@
-if(load_some_attack_data()) exit;
+load_some_attack_data()
 
 xdisp = ai_target.x - x
 ydisp = ai_target.y - y
@@ -41,9 +41,9 @@ if contains([AT_FAIR, AT_NAIR, AT_BAIR, AT_UAIR, AT_DAIR], attack){
 		repeat(50) learn();
 		
 		// if(learning_frame > 15) currently_learning = false;
-		learning_frame++; return(true);
+		learning_frame++; exit;
 	} else {
-		currently_learning = false; return(false);
+		currently_learning = false
 	}
 	/*else {
 		if(learning_frame != 69) {

--- a/scripts/ai_update.gml
+++ b/scripts/ai_update.gml
@@ -346,8 +346,8 @@ if contains([AT_FAIR, AT_NAIR, AT_BAIR, AT_UAIR, AT_DAIR], attack){
 		return p_do_nothing
 	}
 	ai_thoughts = `player 1s AT_FAIR has ${known_attacks[1, AT_FAIR].hitboxes_array[1].frame} hitboxes`;
-	if(player_ids[1].shield_down) get_string("hi?", string(known_attacks[1, AT_FAIR].hitboxes_array));
-
+	if(debug_keyboard_pressed("1")) get_string("hi?", string(known_attacks[1, AT_FAIR].hitboxes_array));
+	
 	var plan = p_do_nothing
 	
 	var frames_to_impact = 9999
@@ -563,6 +563,13 @@ if contains([AT_FAIR, AT_NAIR, AT_BAIR, AT_UAIR, AT_DAIR], attack){
 	shield_down = true
 	parry_pressed = true
 	parry_down = true
+
+#define debug_keyboard_pressed(index)
+	if(keyboard_lastkey == ord(string(index))) {
+		keyboard_lastkey = 0;
+		return(true);
+	}
+	else return(false);
 
 #define direction_to_target()		
 	var direction_to_target = sign(xdisp)

--- a/scripts/ai_update.gml
+++ b/scripts/ai_update.gml
@@ -38,7 +38,7 @@ if contains([AT_FAIR, AT_NAIR, AT_BAIR, AT_UAIR, AT_DAIR], attack){
 			noone
 		];
 		
-		repeat(1) learn();
+		repeat(50) learn();
 		
 		// if(learning_frame > 15) currently_learning = false;
 		learning_frame++; return(true);


### PR DESCRIPTION
Branch name is misleading because github wouldn't let me rename it properly. debug_keyboard_pressed just returns a bool, true or false, depending on whether a key on the keyboard has been pressed this frame. Can be useful for debugging - currently it's set up so that pressing 1 on the keyboard once the AI has finished learning will open a get_string prompt containing information about P1's forward aerial hitboxes. Previously this was set up to happen when player 1 presses Parry, but that was annoying.

Also, I increased the amount of learn()s per frame from 1 to 50 - the game seems to handle that totally fine, and it means that it'll only take 2 frames instead of 100 for the AI to understand every move in a 2-player match.